### PR TITLE
Fixed #12

### DIFF
--- a/src/QnAnalysisCorrect/ATVarManagerTask.hpp
+++ b/src/QnAnalysisCorrect/ATVarManagerTask.hpp
@@ -16,6 +16,9 @@ ATVarManagerTask :
     public UserTask {
 
 public:
+  FillTask *FillTaskPtr() final {
+    return this;
+  }
   void Init(std::map<std::string, void *> &Map) override;
   void Exec() override;
   void Finish() override;

--- a/src/QnAnalysisCorrect/QnCorrectionTask.hpp
+++ b/src/QnAnalysisCorrect/QnCorrectionTask.hpp
@@ -27,7 +27,7 @@ namespace Qn::Analysis::Correction {
  * @brief TestTask for analysing qn vectors
  */
 
-class QnCorrectionTask : public UserTask {
+class QnCorrectionTask : public UserFillTask {
  public:
   QnCorrectionTask() = default;
   explicit QnCorrectionTask(Base::AnalysisSetup* global_config) : analysis_setup_(global_config) {}


### PR DESCRIPTION
The fix was done in both
https://github.com/eugene274/AnalysisTreeTaskSkeleton/commit/9952a860744e1920d62978701ee2f2165a67ee5c
and here.

`FillTask` was uninitialized due to kind of 'diamond' inheritance of `FillTask`. This problem is specific for `ATVarManagerTask` which inherits `FillTask` directly (not via `UserTask`) 

For all tasks which inherit `FillTask`, use `UserTask` as before. Implement `YourTask::FillTaskPtr()` at let it return `this`.
For other tasks use `UserFillTask` instead of `UserTask`. That's all.
