### PR TITLE
QA plots in separate file

### DIFF
--- a/src/QnAnalysisCorrect/QnCorrectionTask.hpp
+++ b/src/QnAnalysisCorrect/QnCorrectionTask.hpp
@@ -54,6 +54,7 @@ class QnCorrectionTask : public UserFillTask {
   std::string yaml_config_file_;
   std::string yaml_config_node_;
 
+  std::string qa_file_name_;
   std::shared_ptr<TFile> out_file_;
   std::string in_calibration_file_name_{"correction_in.root"};
 


### PR DESCRIPTION
Add option `--qa-file`. If `--qa-file` is empty (default if not specified), QA histograms are written together with output.