### PR TITLE
Compatibility of QnAnalysis::Correlate with gcc < 8

### DIFF
--- a/cmake_tests_src/test_filesystem.cxx
+++ b/cmake_tests_src/test_filesystem.cxx
@@ -3,8 +3,12 @@
 //
 
 #include <filesystem>
+#include <iostream>
 
 int main() {
-  std::filesystem::path p{"/"};
+  std::filesystem::path root_path{"/"};
+  auto current_path = std::filesystem::current_path();
+  std::cout << root_path << std::endl;
+  std::cout << current_path << std::endl;
   return 0;
 }

--- a/cmake_tests_src/test_filesystem.cxx
+++ b/cmake_tests_src/test_filesystem.cxx
@@ -1,0 +1,10 @@
+//
+// Created by eugene on 11/08/2021.
+//
+
+#include <filesystem>
+
+int main() {
+  std::filesystem::path p{"/"};
+  return 0;
+}

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -1,4 +1,17 @@
 
+set(CMAKE_CXX_STANDARD 17)
+
+
+try_compile(
+        RESULT_VAR ${CMAKE_BINARY_DIR}
+            ${CMAKE_SOURCE_DIR}/cmake_tests_src/test_filesystem.cxx
+        LINK_LIBRARIES $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
+        OUTPUT_VARIABLE HAS_STD_FILESYSTEM
+)
+if (HAS_STD_FILESYSTEM)
+    message("-- Found std::filesystem")
+endif()
+
 find_package(Boost REQUIRED COMPONENTS program_options)
 
 set(QnAnalysis_SETUPS_DIR ${CMAKE_SOURCE_DIR}/setups)

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -28,13 +28,13 @@ target_link_libraries(QnAnalysisCorrelate
             # link std::filesystem if compiler supports it
             $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
             # link Boost::filesystem if it was found
-            $<$<BOOL:HAS_BOOST_FILESYSTEM>:${BOOST_FILESYSTEM_LIBRARY}>
+            $<$<BOOL:${HAS_BOOST_FILESYSTEM}>:${BOOST_FILESYSTEM_LIBRARY}>
         PUBLIC
         QnToolsDataFrame Boost::program_options yaml-cpp)
 target_compile_definitions(QnAnalysisCorrelate
         PRIVATE
-            $<$<BOOL:HAS_STD_FILESYSTEM>:HAS_STD_FILESYSTEM>
-            $<$<BOOL:HAS_BOOST_FILESYSTEM>:HAS_BOOST_FILESYSTEM>
+            $<$<BOOL:${HAS_STD_FILESYSTEM}>:HAS_STD_FILESYSTEM>
+            $<$<BOOL:${HAS_BOOST_FILESYSTEM}>:HAS_BOOST_FILESYSTEM>
         )
 target_include_directories(QnAnalysisCorrelate PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -3,10 +3,9 @@ set(CMAKE_CXX_STANDARD 17)
 
 
 try_compile(
-        RESULT_VAR ${CMAKE_BINARY_DIR}
-            ${CMAKE_SOURCE_DIR}/cmake_tests_src/test_filesystem.cxx
+        HAS_STD_FILESYSTEM ${CMAKE_BINARY_DIR}
+        SOURCES ${CMAKE_SOURCE_DIR}/cmake_tests_src/test_filesystem.cxx
         LINK_LIBRARIES $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
-        OUTPUT_VARIABLE HAS_STD_FILESYSTEM
 )
 if (HAS_STD_FILESYSTEM)
     message("-- Found std::filesystem")

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -10,6 +10,11 @@ try_compile(
 )
 if (HAS_STD_FILESYSTEM)
     message("-- Found std::filesystem")
+    set(FILESYSTEM_LIB $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
+else()
+    find_package(Boost REQUIRED COMPONENTS filesystem)
+    set(FILESYSTEM_LIB Boost::filesystem)
+    message("-- Found boost::filesystem")
 endif()
 
 find_package(Boost REQUIRED COMPONENTS program_options)
@@ -21,7 +26,7 @@ configure_file(BuildOptions.hpp.in BuildOptions.hpp)
 add_executable(QnAnalysisCorrelate CorrelationMain.cpp CorrelationTaskRunner.cpp)
 target_link_libraries(QnAnalysisCorrelate
         PRIVATE
-        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
+            ${FILESYSTEM_LIB}
         PUBLIC
         QnToolsDataFrame Boost::program_options yaml-cpp)
 target_include_directories(QnAnalysisCorrelate PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -13,7 +13,6 @@ else()
     find_package(Boost REQUIRED COMPONENTS filesystem)
     set(HAS_BOOST_FILESYSTEM ${Boost_FILESYSTEM_FOUND})
     message("-- Found boost::filesystem")
-    message("${Boost_FILESYSTEM_LIBRARY}")
 endif()
 
 find_package(Boost REQUIRED COMPONENTS program_options)
@@ -28,7 +27,7 @@ target_link_libraries(QnAnalysisCorrelate
             # link std::filesystem if compiler supports it
             $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
             # link Boost::filesystem if it was found
-            $<$<BOOL:${HAS_BOOST_FILESYSTEM}>:${Boost_FILESYSTEM_LIBRARY}>
+            $<$<BOOL:${HAS_BOOST_FILESYSTEM}>:Boost::filesystem>
         PUBLIC
         QnToolsDataFrame Boost::program_options yaml-cpp)
 target_compile_definitions(QnAnalysisCorrelate

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -11,9 +11,9 @@ if (HAS_STD_FILESYSTEM)
     message("-- Found std::filesystem")
 else()
     find_package(Boost REQUIRED COMPONENTS filesystem)
-    set(HAS_BOOST_FILESYSTEM ${BOOST_FILESYSTEM_FOUND})
+    set(HAS_BOOST_FILESYSTEM ${Boost_FILESYSTEM_FOUND})
     message("-- Found boost::filesystem")
-    message("${BOOST_FILESYSTEM_LIBRARY}")
+    message("${Boost_FILESYSTEM_LIBRARY}")
 endif()
 
 find_package(Boost REQUIRED COMPONENTS program_options)
@@ -28,7 +28,7 @@ target_link_libraries(QnAnalysisCorrelate
             # link std::filesystem if compiler supports it
             $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
             # link Boost::filesystem if it was found
-            $<$<BOOL:${HAS_BOOST_FILESYSTEM}>:${BOOST_FILESYSTEM_LIBRARY}>
+            $<$<BOOL:${HAS_BOOST_FILESYSTEM}>:${Boost_FILESYSTEM_LIBRARY}>
         PUBLIC
         QnToolsDataFrame Boost::program_options yaml-cpp)
 target_compile_definitions(QnAnalysisCorrelate

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -26,24 +26,17 @@ configure_file(BuildOptions.hpp.in BuildOptions.hpp)
 add_executable(QnAnalysisCorrelate CorrelationMain.cpp CorrelationTaskRunner.cpp)
 target_link_libraries(QnAnalysisCorrelate
         PRIVATE
-            # link std::filesystem if compiles supports it
-            $<
-                $<AND:
-                    $<CXX_COMPILER_ID:GNU>,
-                    $<VERSION_LESS:
-                        $<CXX_COMPILER_VERSION>,
-                        9.0
-                    >
-                >:
-                    stdc++fs
-            >
+            # link std::filesystem if compiler supports it
+            $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
             # link Boost::filesystem if it was found
-            $<
-                $<BOOL:HAS_BOOST_FILESYSTEM>:${BOOST_FILESYSTEM_LIBRARY}
-            >
-
+            $<$<BOOL:HAS_BOOST_FILESYSTEM>:${BOOST_FILESYSTEM_LIBRARY}>
         PUBLIC
         QnToolsDataFrame Boost::program_options yaml-cpp)
+target_compile_definitions(QnAnalysisCorrelate
+        PRIVATE
+            $<$<BOOL:HAS_STD_FILESYSTEM>:HAS_STD_FILESYSTEM>
+            $<$<BOOL:HAS_BOOST_FILESYSTEM>:HAS_BOOST_FILESYSTEM>
+        )
 target_include_directories(QnAnalysisCorrelate PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if (QnAnalysis_BUILD_TESTS)

--- a/src/QnAnalysisCorrelate/CMakeLists.txt
+++ b/src/QnAnalysisCorrelate/CMakeLists.txt
@@ -10,11 +10,11 @@ try_compile(
 )
 if (HAS_STD_FILESYSTEM)
     message("-- Found std::filesystem")
-    set(FILESYSTEM_LIB $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
 else()
     find_package(Boost REQUIRED COMPONENTS filesystem)
-    set(FILESYSTEM_LIB Boost::filesystem)
+    set(HAS_BOOST_FILESYSTEM ${BOOST_FILESYSTEM_FOUND})
     message("-- Found boost::filesystem")
+    message("${BOOST_FILESYSTEM_LIBRARY}")
 endif()
 
 find_package(Boost REQUIRED COMPONENTS program_options)
@@ -26,7 +26,22 @@ configure_file(BuildOptions.hpp.in BuildOptions.hpp)
 add_executable(QnAnalysisCorrelate CorrelationMain.cpp CorrelationTaskRunner.cpp)
 target_link_libraries(QnAnalysisCorrelate
         PRIVATE
-            ${FILESYSTEM_LIB}
+            # link std::filesystem if compiles supports it
+            $<
+                $<AND:
+                    $<CXX_COMPILER_ID:GNU>,
+                    $<VERSION_LESS:
+                        $<CXX_COMPILER_VERSION>,
+                        9.0
+                    >
+                >:
+                    stdc++fs
+            >
+            # link Boost::filesystem if it was found
+            $<
+                $<BOOL:HAS_BOOST_FILESYSTEM>:${BOOST_FILESYSTEM_LIBRARY}
+            >
+
         PUBLIC
         QnToolsDataFrame Boost::program_options yaml-cpp)
 target_include_directories(QnAnalysisCorrelate PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/QnAnalysisCorrelate/Config.hpp
+++ b/src/QnAnalysisCorrelate/Config.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <yaml-cpp/yaml.h>
 #include <regex>
+#include <optional>
 #include <cassert>
 
 namespace YAMLHelper {

--- a/src/QnAnalysisCorrelate/CorrelationTaskRunner.cpp
+++ b/src/QnAnalysisCorrelate/CorrelationTaskRunner.cpp
@@ -2,8 +2,6 @@
 // Created by eugene on 21/07/2020.
 //
 
-#include <filesystem>
-
 #include <yaml-cpp/yaml.h>
 
 #include <BuildOptions.hpp>
@@ -16,8 +14,8 @@
 #include <TDirectory.h>
 #include <TObjString.h>
 
-using std::filesystem::path;
-using std::filesystem::current_path;
+using fs::path;
+using fs::current_path;
 using namespace Qn::Analysis::Correlate;
 
 
@@ -95,7 +93,7 @@ void Qn::Analysis::Correlate::CorrelationTaskRunner::LookupConfiguration() {
 
 }
 
-bool Qn::Analysis::Correlate::CorrelationTaskRunner::LoadConfiguration(const std::filesystem::path &path) {
+bool Qn::Analysis::Correlate::CorrelationTaskRunner::LoadConfiguration(const fs::path &path) {
   using namespace YAML;
 
   Node top_node;

--- a/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
+++ b/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
@@ -10,12 +10,14 @@
 #include <vector>
 #include <string>
 
-#include <filesystem>
-#ifdef __cpp_lib_filesystem
-#pragma message("Using std::filesystem")
-#else
-#pragma message("std::filesystem is not found")
+#if defined(HAS_STD_FILESYSTEM)
+# include <filesystem>
+namespace fs = ::std::filesystem;
+#elif defined(HAS_BOOST_FILESYSTEM)
+# include <boost/filesystem.hpp>
+namespace fs = ::boost::filesystem;
 #endif
+
 
 #include <QnDataFrame.hpp>
 #include <TFile.h>
@@ -97,7 +99,7 @@ class CorrelationTaskRunner {
     size_t arity{0};
     size_t n_axes{0};
     std::list<Correlation> correlations;
-    std::filesystem::path output_folder;
+    fs::path output_folder;
   };
 
   struct bad_config_file : public std::exception {
@@ -125,7 +127,7 @@ class CorrelationTaskRunner {
   std::shared_ptr<TTree> GetTree();
   std::shared_ptr<ROOT::RDataFrame> GetRDF();
   void LookupConfiguration();
-  bool LoadConfiguration(const std::filesystem::path &path);
+  bool LoadConfiguration(const fs::path &path);
 
   static std::vector<Correlation> GetTaskCombinations(const CorrelationTask &args);
 
@@ -174,7 +176,7 @@ class CorrelationTaskRunner {
   template<size_t NAxes>
   static bool PredicateNAxes(const CorrelationTask &t) { return t.axes.size() == NAxes; }
 
-  static TDirectory *mkcd(const std::filesystem::path &path, TDirectory &root_dir);
+  static TDirectory *mkcd(const fs::path &path, TDirectory &root_dir);
 
   static std::string GenCorrelationMeta(const Correlation &c);
 
@@ -223,7 +225,7 @@ class CorrelationTaskRunner {
     auto df = GetRDF();
     auto df_sampled = Qn::Correlation::Resample(*df, t.n_samples);
 
-    result->output_folder = std::filesystem::path(t.output_folder);
+    result->output_folder = fs::path(t.output_folder);
     if (result->output_folder.is_relative()) {
       throw std::runtime_error("Output folder must be an absolute path");
     }
@@ -285,11 +287,11 @@ class CorrelationTaskRunner {
 
   void InitializeTasks();
 
-  std::filesystem::path configuration_file_path_{};
+  fs::path configuration_file_path_{};
   std::string configuration_node_name_{};
   std::string output_file_;
 
-  std::filesystem::path input_file_name_;
+  fs::path input_file_name_;
   std::string input_tree_;
 
   std::vector<CorrelationTask> config_tasks_;

--- a/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
+++ b/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
@@ -9,7 +9,13 @@
 #include <utility>
 #include <vector>
 #include <string>
+
 #include <filesystem>
+#ifdef __cpp_lib_filesystem
+#pragma message("Using std::filesystem")
+#else
+#pragma message("std::filesystem is not found")
+#endif
 
 #include <QnDataFrame.hpp>
 #include <TFile.h>


### PR DESCRIPTION
 QnAnalysisCorrelated uses `<filesystem>` from the standard library, which appeared starting from ~ gcc8.
To preserve compatibility with old versions of compilers, availibility of std::filesystem is checked on CMake level.
If not available, it fallbacks to `boost::filesystem` with similar interface.


