### PR TITLE
create bootstrap dataframe the same for all tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Correlation options:
   -i [ --input-file ] arg          Name of the input ROOT file (or .list file)
   -i [ --input-tree ] arg (=tree)  Name of the input tree
   -o [ --output-file ] arg         Name of the output ROOT file
+  --n-samples arg (=50)            Number of bootstrap samples
 ```
 
 `--input-file` is either a ROOT file (.root) or list of ROOT files (*.list). 
@@ -133,7 +134,6 @@ User provides list of tasks to evaluate.
 A task consists of:
 - Task arguments
 - Task action 
-- Number of samples for bootstrapping
 - Event axes
 - Folder in the output file
 
@@ -219,7 +219,6 @@ args:
     query-list: *detectors
     components: [x1,y1,cos1,sin1]
     correction-steps: [ recentered ]
-n-samples: 50
 weights-type: reference
 folder: "/QQ/test"
 axes: [ *centrality ]

--- a/src/QnAnalysisCorrelate/Config.hpp
+++ b/src/QnAnalysisCorrelate/Config.hpp
@@ -153,7 +153,6 @@ struct CorrelationTask {
   std::vector<AxisConfig> axes;
   EQnWeight weight_type{EQnWeight::REFERENCE};
   std::string weights_function;
-  int n_samples{0};
   std::string output_folder;
 };
 
@@ -326,7 +325,6 @@ struct convert<Qn::Analysis::Correlate::CorrelationTask> {
     using namespace Qn::Analysis::Correlate;
     task.arguments = node["args"].as<std::vector<CorrelationTaskArgument>>();
 //    task.actions = node["actions"].as<std::vector<std::string>>();
-    task.n_samples = node["n-samples"].as<int>();
     task.axes = node["axes"].as<std::vector<AxisConfig>>();
     task.weight_type = node["weights-type"].as<Enum<EQnWeight>>();
 //    if (task.weight_type == EQnWeight(EQnWeight::OBSERVABLE)) {

--- a/src/QnAnalysisCorrelate/Config.hpp
+++ b/src/QnAnalysisCorrelate/Config.hpp
@@ -325,6 +325,12 @@ struct convert<Qn::Analysis::Correlate::CorrelationTask> {
     using namespace Qn::Analysis::Correlate;
     task.arguments = node["args"].as<std::vector<CorrelationTaskArgument>>();
 //    task.actions = node["actions"].as<std::vector<std::string>>();
+    if(node["n-samples"]) {
+      std::string message = "n-samples is not task's property, but a global number.\n";
+      message.append("Must be set as a command line argument --n-samples.\n");
+      message.append("See PR #58 https://github.com/HeavyIonAnalysis/QnAnalysis/pull/58");
+      throw std::runtime_error(message.c_str());
+    }
     task.axes = node["axes"].as<std::vector<AxisConfig>>();
     task.weight_type = node["weights-type"].as<Enum<EQnWeight>>();
 //    if (task.weight_type == EQnWeight(EQnWeight::OBSERVABLE)) {

--- a/src/QnAnalysisCorrelate/CorrelationTaskRunner.cpp
+++ b/src/QnAnalysisCorrelate/CorrelationTaskRunner.cpp
@@ -284,6 +284,6 @@ CorrelationTaskRunner::QVectorWeightFct CorrelationTaskRunner::GetQVectorWeightF
 }
 
 CorrelationTaskRunner::~CorrelationTaskRunner() {
-  if(df_sampled_) delete df_sampled_;
+  if(df_sampled_!=nullptr) delete df_sampled_;
 }
 

--- a/src/QnAnalysisCorrelate/CorrelationTaskRunner.cpp
+++ b/src/QnAnalysisCorrelate/CorrelationTaskRunner.cpp
@@ -28,12 +28,15 @@ boost::program_options::options_description Qn::Analysis::Correlate::Correlation
       ("configuration-name", value(&configuration_node_name_)->required(), "Name of YAML node")
       ("input-file,i", value(&input_file_name_)->required(), "Name of the input ROOT file (or .list file)")
       ("input-tree,i", value(&input_tree_)->default_value("tree"), "Name of the input tree")
-      ("output-file,o", value(&output_file_)->required(), "Name of the output ROOT file");
+      ("output-file,o", value(&output_file_)->required(), "Name of the output ROOT file")
+      ("n-samples", value(&n_samples_)->default_value(50), "Number of bootstrap samples");
 
   return desc;
 }
 
 void Qn::Analysis::Correlate::CorrelationTaskRunner::Initialize() {
+  df_ = GetRDF();
+  df_sampled_ = new ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>(Qn::Correlation::Resample(*df_, n_samples_));
   LookupConfiguration();
   InitializeTasks();
 }
@@ -278,5 +281,9 @@ CorrelationTaskRunner::QVectorWeightFct CorrelationTaskRunner::GetQVectorWeightF
   } else {
     throw bad_qvector_weight();
   }
+}
+
+CorrelationTaskRunner::~CorrelationTaskRunner() {
+  if(df_sampled_) delete df_sampled_;
 }
 

--- a/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
+++ b/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
@@ -123,11 +123,17 @@ class CorrelationTaskRunner {
 
   void Run();
 
+  ~CorrelationTaskRunner();
+
  private:
   std::shared_ptr<TTree> GetTree();
   std::shared_ptr<ROOT::RDataFrame> GetRDF();
   void LookupConfiguration();
   bool LoadConfiguration(const fs::path &path);
+
+  int n_samples_{0};
+  std::shared_ptr<ROOT::RDataFrame> df_;
+  ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>* df_sampled_;
 
   static std::vector<Correlation> GetTaskCombinations(const CorrelationTask &args);
 
@@ -221,9 +227,6 @@ class CorrelationTaskRunner {
 //    auto weight_function = GetActionRegistry().Get(weight_function_name);
 
     auto result = std::make_shared<CorrelationTaskInitialized>();
-    /* init RDataFrame */
-    auto df = GetRDF();
-    auto df_sampled = Qn::Correlation::Resample(*df, t.n_samples);
 
     result->output_folder = fs::path(t.output_folder);
     if (result->output_folder.is_relative()) {
@@ -245,7 +248,7 @@ class CorrelationTaskRunner {
             use_weights,
             args_list_array,
             axes_config,
-            t.n_samples)).BookMe(df_sampled);
+            n_samples_)).BookMe(*df_sampled_);
 
         correlation.result_ptr = booked_action;
 

--- a/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
+++ b/src/QnAnalysisCorrelate/CorrelationTaskRunner.hpp
@@ -133,7 +133,7 @@ class CorrelationTaskRunner {
 
   int n_samples_{0};
   std::shared_ptr<ROOT::RDataFrame> df_;
-  ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>* df_sampled_;
+  ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager>* df_sampled_{nullptr};
 
   static std::vector<Correlation> GetTaskCombinations(const CorrelationTask &args);
 


### PR DESCRIPTION
In current implementation of QnAnalysis the bootstrap samples were created independently for different QnAnalysis::Correlation tasks. Therefore effectively correlations were assumed to be uncorrelated between each other. So the error on a complex quantity (such as v = \<uQ\> / R) was calculated with implicit assumption of statistical independence of numerator and denominator.

In this PR this problem is fixed.