### PR TITLE
Get AnalysisTreeTaskSkeleton from HeavyIonAnalysis

### DIFF
--- a/cmake_modules/AnalysisTreeTaskSkeleton.cmake
+++ b/cmake_modules/AnalysisTreeTaskSkeleton.cmake
@@ -1,6 +1,6 @@
 FetchContent_Declare(ATTaskSkeleton
-        GIT_REPOSITORY https://github.com/lubynets/AnalysisTreeTaskSkeleton.git
-        GIT_TAG "at_cuts_hash"
+        GIT_REPOSITORY https://github.com/HeavyionAnalysis/AnalysisTreeTaskSkeleton.git
+        GIT_TAG "master"
         GIT_SHALLOW ON
         UPDATE_DISCONNECTED ${UPDATE_DISCONNECTED}
         )


### PR DESCRIPTION
Before the dependency package AnalysisTreeTaskSkeleton was downloaded by default from personal repositories of **eugene274** and **lubynets**. Now it was moved to HeavyIonAnalysis and will be downloaded by QnAnalysis from there by default.