### PR TITLE
cmake_modules/QnTools: make more flexible and update hash

### DIFF
--- a/cmake_modules/QnTools.cmake
+++ b/cmake_modules/QnTools.cmake
@@ -1,28 +1,31 @@
-if (QNTOOLS_ROOT)
-    message("-- Uing external QnTools from ${QNTOOLS_ROOT}")
-    set(CMAKE_PREFIX_PATH ${QNTOOLS_ROOT} ${CMAKE_PREFIX_PATH})
-    find_package(QnTools)
-    list(APPEND PROJECT_INCLUDE_DIRECTORIES ${QnTools_INCLUDE_DIR})
-else()
+find_package(QnTools QUIET)
+if(NOT QnTools_FOUND)
+    message("-- QnTools not found, will be built automatically")
+
+    set(QnAnalysis_BUNDLED_QNT_URL "https://github.com/HeavyIonAnalysis/QnTools.git" CACHE STRING "Bundled QnTools URL")
+    set(QnAnalysis_BUNDLED_QNT_VERSION "7789d40de12a8936fb0bac67ad7313c345177a20" CACHE STRING "Bundled QnTools version")
+    set(QnAnalysis_BUNDLED_QNT_GIT_SHALLOW ON CACHE BOOL "Use CMake GIT_SHALLOW option")
 
     include(FetchContent)
     FetchContent_Declare(QnTools
-            GIT_REPOSITORY https://github.com/HeavyIonAnalysis/QnTools.git
-            GIT_TAG "7789d40de12a8936fb0bac67ad7313c345177a20"
-            UPDATE_DISCONNECTED ${UPDATE_DISCONNECTED}
-            )
-    
+        GIT_REPOSITORY  ${QnAnalysis_BUNDLED_QNT_URL}
+        GIT_TAG         ${QnAnalysis_BUNDLED_QNT_VERSION}
+        GIT_SHALLOW     ${QnAnalysis_BUNDLED_QNT_GIT_SHALLOW}
+        UPDATE_DISCONNECTED ${UPDATE_DISCONNECTED}
+    )
+
     FetchContent_GetProperties(QnTools)
     if(NOT qntools_POPULATED)
         FetchContent_Populate(QnTools)
         set(QnTools_BUILD_TESTS OFF)
         add_subdirectory(${qntools_SOURCE_DIR} ${qntools_BINARY_DIR})
     endif()
-    
+
     get_target_property(QnToolsBase_INCLUDE_DIRS QnToolsBase INCLUDE_DIRECTORIES)
     list(APPEND PROJECT_INCLUDE_DIRECTORIES ${QnToolsBase_INCLUDE_DIRS})
     get_target_property(QnToolsCorrection_INCLUDE_DIRS QnToolsCorrection INCLUDE_DIRECTORIES)
     list(APPEND PROJECT_INCLUDE_DIRECTORIES ${QnToolsCorrection_INCLUDE_DIRS})
-
-endif(QNTOOLS_ROOT)
-
+else()
+    message("-- QnTools found")
+    list(APPEND PROJECT_INCLUDE_DIRECTORIES ${QnTools_INCLUDE_DIR})
+endif()

--- a/cmake_modules/QnTools.cmake
+++ b/cmake_modules/QnTools.cmake
@@ -3,7 +3,7 @@ if(NOT QnTools_FOUND)
     message("-- QnTools not found, will be built automatically")
 
     set(QnAnalysis_BUNDLED_QNT_URL "https://github.com/HeavyIonAnalysis/QnTools.git" CACHE STRING "Bundled QnTools URL")
-    set(QnAnalysis_BUNDLED_QNT_VERSION "7789d40de12a8936fb0bac67ad7313c345177a20" CACHE STRING "Bundled QnTools version")
+    set(QnAnalysis_BUNDLED_QNT_VERSION "e171555314fc3608f45cf3e1763f8650b33a5e2a" CACHE STRING "Bundled QnTools version")
     set(QnAnalysis_BUNDLED_QNT_GIT_SHALLOW ON CACHE BOOL "Use CMake GIT_SHALLOW option")
 
     include(FetchContent)


### PR DESCRIPTION
1. The `cmake_modules/QnTools.cmake` is made more flexible, so user can provide url and hash / tag / branch of the required QnTools version. The possibility of usage of pre-installed QnTools is also guaranteed. For the reference the [AnalysisTree.cmake](https://github.com/HeavyIonAnalysis/AnalysisTreeQA/blob/7c57f07dee25fd52d03e56e211f8820b9a500f1e/cmake_modules/AnalysisTree.cmake) from the [AnalysisTreeQA](https://github.com/HeavyIonAnalysis/AnalysisTreeQA) package was taken.
2. Updated the default hash of QnTools, which is compatible with ROOT 6.36.